### PR TITLE
Add Symfony 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.1",
 
         "doctrine/orm": "^2.20 || ^3.3",
-        "symfony/property-access": "^5.4 || ^6.4 || ^7.1"
+        "symfony/property-access": "^5.4 || ^6.4 || ^7.4 || ^8.0"
     },
     "autoload": {
         "psr-4": { "SyliusLabs\\AssociationHydrator\\": "src/" }


### PR DESCRIPTION
Add `|| ^8.0` constraint to `symfony/property-access` requirement.