### PR TITLE
Add Symfony 8 and PHP 8.5 to CI matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,16 +19,18 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.2, 8.3, 8.4]
-                symfony: [5.4.*, 6.4.*, 7.1.*, 7.2.*]
+                php: [8.1, 8.2, 8.3, 8.4, 8.5]
+                symfony: [5.4.*, 6.4.*, 7.4.*, 8.0.*]
                 orm: [^2.20, ^3.3]
                 exclude:
                     - php: 8.1
-                      symfony: 7.0.*
+                      symfony: 7.4.*
                     - php: 8.1
-                      symfony: 7.1.*
-                    - php: 8.1
-                      symfony: 7.2.*
+                      symfony: 8.0.*
+                    - php: 8.2
+                      symfony: 8.0.*
+                    - php: 8.3
+                      symfony: 8.0.*
 
         steps:
             -


### PR DESCRIPTION
Add Symfony 8.0 and PHP 8.5 builds to CI matrix.